### PR TITLE
Select log file to open with --open/-o

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ deoptigate -- node --allow-natives-syntax app.js
 
 Simply run `deoptigate` from the directory that contains the log file(s).
 
+### Deoptigate existing `*.log`
+
+Run `deoptigate --open path/to/file.log`. You may also use `-o`.
+
 ## License
 
 MIT

--- a/bin/deoptigate
+++ b/bin/deoptigate
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+const path = require('path')
+
 const { blue, red } = require('ansicolors')
 const simpleHead = blue('deoptigate')
 const happyHead = blue('deoptigate 💪')
@@ -11,11 +13,19 @@ const createLog = require('./deoptigate.create-log')
 
 ;(async () => {
   try {
-    const log = (process.argv.length <= 2
+    const argv = process.argv
+    const argLength = process.argv.length
+    const shouldOpen = (argv[2] == '--open' || argv[2] == '-o')
+    if (argLength == 4 && shouldOpen) {
+      return await openLog(path.resolve(argv[3]), happyHead)
+    }
+
+    const log = (argLength <= 2
       ? await findLog(happyHead)
-      : await createLog(process.argv.slice(2), happyHead, simpleHead)
+      : await createLog(argv.slice(2), happyHead, simpleHead)
     )
     await openLog(log, happyHead)
+
   } catch (err) {
     console.error(`${errorHead}: ${err}`)
   }


### PR DESCRIPTION
`deoptigate -o some_named_log_file.log` now works, as well as `--open`.

It's nice to be able to name my log files whatever I want.