### PR TITLE
Added browser support and fixed Windows issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,23 +87,23 @@ Simply run `deoptigate` from the directory that contains the log file(s).
 ### To capture a browser session
 
 Launch a Chromium-based browser with the necessary tracing flags. For example,
-here running on localhost and writing the log file to the `/temp/trace` directory.
+running on localhost and writing the log file to the `/temp/trace` directory:
 
 ```
-%browser_exe% --no-sandbox --js-flags="--trace-ic --nologfile-per-isolate --logfile=/temp/trace/v8.log" http://localhost:8000/
+%browser% --no-sandbox --js-flags="--trace-ic --nologfile-per-isolate --logfile=/temp/trace/v8.log" http://localhost:8000/
 ```
 
 When running with no sandbox, you can also load pages directly from disk, e.g.
 
 ```
-%browser_exe% --no-sandbox --disable-extensions --js-flags="--trace-ic --nologfile-per-isolate --logfile=/temp/trace/v8.log" c:\temp\trace\default.html
+%browser% --no-sandbox --disable-extensions --js-flags="--trace-ic --nologfile-per-isolate --logfile=/temp/trace/v8.log" c:\temp\trace\default.html
 ```
 
 With the directory containing the log file as the current directory, run `deoptigate`.
 
 _Note: The JavaScript files to analyze must be laid out in the current directory
 as they are in the URL path. For example, if the browser loaded a file at
-`http://localhost:8000/js/app.js` above, then the file should exist at `/temp/tracing/js/app.js`.
+`http://localhost:8000/js/app.js` above, then the file should exist at `/temp/trace/js/app.js`.
 If the local copy does not exist, it will not appear in the analysis._
 
 ## License

--- a/README.md
+++ b/README.md
@@ -84,6 +84,28 @@ deoptigate -- node --allow-natives-syntax app.js
 
 Simply run `deoptigate` from the directory that contains the log file(s).
 
+### To capture a browser session
+
+Launch a Chromium-based browser with the necessary tracing flags. For example,
+here running on localhost and writing the log file to the `/temp/trace` directory.
+
+```
+%browser_exe% --no-sandbox --js-flags="--trace-ic --nologfile-per-isolate --logfile=/temp/trace/v8.log" http://localhost:8000/
+```
+
+When running with no sandbox, you can also load pages directly from disk, e.g.
+
+```
+%browser_exe% --no-sandbox --disable-extensions --js-flags="--trace-ic --nologfile-per-isolate --logfile=/temp/trace/v8.log" c:\temp\trace\default.html
+```
+
+With the directory containing the log file as the current directory, run `deoptigate`.
+
+_Note: The JavaScript files to analyze must be laid out in the current directory
+as they are in the URL path. For example, if the browser loaded a file at
+`http://localhost:8000/js/app.js` above, then the file should exist at `/temp/tracing/js/app.js`.
+If the local copy does not exist, it will not appear in the analysis._
+
 ## License
 
 MIT

--- a/app/build/deoptigate.js
+++ b/app/build/deoptigate.js
@@ -27824,7 +27824,7 @@ module.exports = camelizeStyleName;
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * 
+ *
  */
 
 var isTextNode = require('./isTextNode');
@@ -27862,7 +27862,7 @@ module.exports = containsNode;
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * 
+ *
  */
 
 function makeEmptyFunction(arg) {
@@ -28125,7 +28125,7 @@ module.exports = isTextNode;
  * LICENSE file in the root directory of this source tree.
  *
  * @typechecks
- * 
+ *
  */
 
 /*eslint-disable no-self-compare */
@@ -30875,8 +30875,17 @@ module.exports = summarizeFile
 const { severityOfOptimizationState }  = require('./optimization-state')
 
 function normalizeFile(file) {
-  // Node.js adds :line:column to the end
-  return file.split(':')[0]
+  // Web servers will have a prefix like: http://localhost:8000/app.js (needs to be just app.js)
+  // Files from Windows something like: file:///C:/temp/app.js (needs to be just /temp/app.js)
+  // Files from Linux something like: file:///home/bill/app.js (needs to be just /home/bill/app.js)
+  const webPrefix = /((https?:\/\/[^\/]*\/)|(file:\/\/\/[a-zA-Z]:)|(file:\/\/))/
+  file = file.replace(webPrefix, "")
+
+  // Location includes :line:column to the end
+  const re = /(.*):([0-9]+):([0-9]+)$/
+  const array = re.exec(file)
+  if (!array) return file
+  return array[1]
 }
 
 class CodeEntry {
@@ -30918,7 +30927,21 @@ module.exports = CodeEntry
 const { MIN_SEVERITY } = require('../severities')
 
 // <../examples/adders.js:93:27
-const sourcePositionRx = /[<]([^:]+):(\d+):(\d+)[>]/
+const sourcePositionRx = /[<](.*):([0-9]+):([0-9]+)[>]$/
+
+function normalizeFile(file) {
+  // Web servers will have a prefix like: http://localhost:8000/app.js (needs to be just app.js)
+  // Files from Windows something like: file:///C:/temp/app.js (needs to be just /temp/app.js)
+  // Files from Linux something like: file:///home/bill/app.js (needs to be just /home/bill/app.js)
+  const webPrefix = /((https?:\/\/[^\/]*\/)|(file:\/\/\/[a-zA-Z]:)|(file:\/\/))/
+  file = file.replace(webPrefix, "")
+
+  // Location includes :line:column to the end
+  const re = /(.*):([0-9]+):([0-9]+)$/
+  const array = re.exec(file)
+  if (!array) return file
+  return array[1]
+}
 
 function safeToInt(x) {
   if (x == null) return 0
@@ -30990,7 +31013,7 @@ class DeoptEntry {
   static disassembleSourcePosition(sourcePosition) {
     const m = sourcePositionRx.exec(sourcePosition)
     if (m == null) return { file: null, line: 0, column: 0 }
-    return { file: m[1], line: safeToInt(m[2]), column: safeToInt(m[3]) }
+    return { file: normalizeFile(m[1]), line: safeToInt(m[2]), column: safeToInt(m[3]) }
   }
 }
 
@@ -31005,8 +31028,17 @@ const {
 } = require('./ic-state')
 
 function normalizeFile(file) {
-  // Node.js adds :line:column to the end
-  return file.split(':')[0]
+  // Web servers will have a prefix like: http://localhost:8000/app.js (needs to be just app.js)
+  // Files from Windows something like: file:///C:/temp/app.js (needs to be just /temp/app.js)
+  // Files from Linux something like: file:///home/bill/app.js (needs to be just /home/bill/app.js)
+  const webPrefix = /((https?:\/\/[^\/]*\/)|(file:\/\/\/[a-zA-Z]:)|(file:\/\/))/
+  file = file.replace(webPrefix, "")
+
+  // Location includes :line:column to the end
+  const re = /(.*):([0-9]+):([0-9]+)$/
+  const array = re.exec(file)
+  if (!array) return file
+  return array[1]
 }
 
 function unquote(s) {
@@ -31812,7 +31844,7 @@ CodeMap.NameGenerator.prototype.getName = function(name) {
 if (typeof module === 'object' && typeof module.exports === 'object') {
   var SplayTree = require('./splaytree.js')
   module.exports = CodeMap;
-} 
+}
 
 },{"./splaytree.js":73}],70:[function(require,module,exports){
 // Copyright 2009 the V8 project authors. All rights reserved.
@@ -31920,7 +31952,7 @@ class CsvParser {
 
 if (typeof module === 'object' && typeof module.exports === 'object') {
   module.exports = CsvParser;
-} 
+}
 
 },{}],71:[function(require,module,exports){
 // Copyright 2011 the V8 project authors. All rights reserved.
@@ -32162,7 +32194,7 @@ LogReader.prototype.processLog_ = function(lines) {
 if (typeof module === 'object' && typeof module.exports === 'object') {
   var CsvParser = require('./csvparser.js')
   module.exports = LogReader;
-} 
+}
 
 },{"./csvparser.js":70}],72:[function(require,module,exports){
 // Copyright 2009 the V8 project authors. All rights reserved.
@@ -32199,7 +32231,7 @@ if (typeof module === 'object' && typeof module.exports === 'object') {
     CallTree,
     JsonProfile
   };
-} 
+}
 
 /**
  * Creates a profile object for processing profiling-related events
@@ -33629,7 +33661,7 @@ SplayTree.Node.prototype.right = null;
 
 if (typeof module === 'object' && typeof module.exports === 'object') {
   module.exports = SplayTree;
-} 
+}
 
 },{}]},{},[7])(7)
 });

--- a/app/build/deoptigate.js
+++ b/app/build/deoptigate.js
@@ -27824,7 +27824,7 @@ module.exports = camelizeStyleName;
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- *
+ * 
  */
 
 var isTextNode = require('./isTextNode');
@@ -27862,7 +27862,7 @@ module.exports = containsNode;
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- *
+ * 
  */
 
 function makeEmptyFunction(arg) {
@@ -28125,7 +28125,7 @@ module.exports = isTextNode;
  * LICENSE file in the root directory of this source tree.
  *
  * @typechecks
- *
+ * 
  */
 
 /*eslint-disable no-self-compare */
@@ -30875,13 +30875,16 @@ module.exports = summarizeFile
 const { severityOfOptimizationState }  = require('./optimization-state')
 
 function normalizeFile(file) {
-  // Web servers will have a prefix like: http://localhost:8000/app.js (needs to be just app.js)
-  // Files from Windows something like: file:///C:/temp/app.js (needs to be just /temp/app.js)
-  // Files from Linux something like: file:///home/bill/app.js (needs to be just /home/bill/app.js)
+  // When tracing from the browser, additional filename formats need to be handled:
+  //  - Web servers will have a format like: http://localhost:8000/app.js (needs to be just app.js)
+  //  - Files from Windows something like: file:///C:/temp/app.js (needs to be just /temp/app.js)
+  //  - Files from Linux something like: file:///home/bill/app.js (needs to be just /home/bill/app.js)
   const webPrefix = /((https?:\/\/[^\/]*\/)|(file:\/\/\/[a-zA-Z]:)|(file:\/\/))/
   file = file.replace(webPrefix, "")
 
-  // Location includes :line:column to the end
+  // Location includes :line:column to the end. Note that browser traces include
+  // psuedo-filenames like "extensions::SafeBuiltins", so only consider the last
+  // two colons for a match.
   const re = /(.*):([0-9]+):([0-9]+)$/
   const array = re.exec(file)
   if (!array) return file
@@ -30926,17 +30929,23 @@ module.exports = CodeEntry
 
 const { MIN_SEVERITY } = require('../severities')
 
-// <../examples/adders.js:93:27
-const sourcePositionRx = /[<](.*):([0-9]+):([0-9]+)[>]$/
+// <../examples/adders.js:93:27 or <file:///C:/temp/trace/lib/app.js:20:12>
+// Note that the format may be something like the below, in which case the
+// first location shown is the better one to return.
+//    <lib/app.js:20:12> inlined at <lib/app.js:25:44>
+const sourcePositionRx = /[<]([^>]*):([0-9]+):([0-9]+)[>]/
 
 function normalizeFile(file) {
-  // Web servers will have a prefix like: http://localhost:8000/app.js (needs to be just app.js)
-  // Files from Windows something like: file:///C:/temp/app.js (needs to be just /temp/app.js)
-  // Files from Linux something like: file:///home/bill/app.js (needs to be just /home/bill/app.js)
+  // When tracing from the browser, additional filename formats need to be handled:
+  //  - Web servers will have a format like: http://localhost:8000/app.js (needs to be just app.js)
+  //  - Files from Windows something like: file:///C:/temp/app.js (needs to be just /temp/app.js)
+  //  - Files from Linux something like: file:///home/bill/app.js (needs to be just /home/bill/app.js)
   const webPrefix = /((https?:\/\/[^\/]*\/)|(file:\/\/\/[a-zA-Z]:)|(file:\/\/))/
   file = file.replace(webPrefix, "")
 
-  // Location includes :line:column to the end
+  // Location includes :line:column to the end. Note that browser traces include
+  // psuedo-filenames like "extensions::SafeBuiltins", so only consider the last
+  // two colons for a match.
   const re = /(.*):([0-9]+):([0-9]+)$/
   const array = re.exec(file)
   if (!array) return file
@@ -31028,13 +31037,16 @@ const {
 } = require('./ic-state')
 
 function normalizeFile(file) {
-  // Web servers will have a prefix like: http://localhost:8000/app.js (needs to be just app.js)
-  // Files from Windows something like: file:///C:/temp/app.js (needs to be just /temp/app.js)
-  // Files from Linux something like: file:///home/bill/app.js (needs to be just /home/bill/app.js)
+  // When tracing from the browser, additional filename formats need to be handled:
+  //  - Web servers will have a format like: http://localhost:8000/app.js (needs to be just app.js)
+  //  - Files from Windows something like: file:///C:/temp/app.js (needs to be just /temp/app.js)
+  //  - Files from Linux something like: file:///home/bill/app.js (needs to be just /home/bill/app.js)
   const webPrefix = /((https?:\/\/[^\/]*\/)|(file:\/\/\/[a-zA-Z]:)|(file:\/\/))/
   file = file.replace(webPrefix, "")
 
-  // Location includes :line:column to the end
+  // Location includes :line:column to the end. Note that browser traces include
+  // psuedo-filenames like "extensions::SafeBuiltins", so only consider the last
+  // two colons for a match.
   const re = /(.*):([0-9]+):([0-9]+)$/
   const array = re.exec(file)
   if (!array) return file
@@ -31844,7 +31856,7 @@ CodeMap.NameGenerator.prototype.getName = function(name) {
 if (typeof module === 'object' && typeof module.exports === 'object') {
   var SplayTree = require('./splaytree.js')
   module.exports = CodeMap;
-}
+} 
 
 },{"./splaytree.js":73}],70:[function(require,module,exports){
 // Copyright 2009 the V8 project authors. All rights reserved.
@@ -31952,7 +31964,7 @@ class CsvParser {
 
 if (typeof module === 'object' && typeof module.exports === 'object') {
   module.exports = CsvParser;
-}
+} 
 
 },{}],71:[function(require,module,exports){
 // Copyright 2011 the V8 project authors. All rights reserved.
@@ -32194,7 +32206,7 @@ LogReader.prototype.processLog_ = function(lines) {
 if (typeof module === 'object' && typeof module.exports === 'object') {
   var CsvParser = require('./csvparser.js')
   module.exports = LogReader;
-}
+} 
 
 },{"./csvparser.js":70}],72:[function(require,module,exports){
 // Copyright 2009 the V8 project authors. All rights reserved.
@@ -32231,7 +32243,7 @@ if (typeof module === 'object' && typeof module.exports === 'object') {
     CallTree,
     JsonProfile
   };
-}
+} 
 
 /**
  * Creates a profile object for processing profiling-related events
@@ -33661,7 +33673,7 @@ SplayTree.Node.prototype.right = null;
 
 if (typeof module === 'object' && typeof module.exports === 'object') {
   module.exports = SplayTree;
-}
+} 
 
 },{}]},{},[7])(7)
 });

--- a/deoptigate.js
+++ b/deoptigate.js
@@ -221,6 +221,12 @@ class DeoptProcessor extends LogReader {
       next = string.indexOf('\n', current)
       if (next === -1) break
       line = string.substring(current, next)
+      // TODO: Remove next line once v8-tools-core is updated to include the fix
+      // from https://chromium-review.googlesource.com/c/v8/v8/+/1169049/
+      // Effectively assume backslashes are Windows separators than can be replaced
+      // with a forward-slash benignly. This replaces an escaped backslash "\\" in
+      // the log with a (non-escaped) forward slash.
+      line = line.replace(/\\\\/g, "/")
       current = next + 1
       this.processLogLine(line)
     }

--- a/lib/log-processing/code-entry.js
+++ b/lib/log-processing/code-entry.js
@@ -3,13 +3,16 @@
 const { severityOfOptimizationState }  = require('./optimization-state')
 
 function normalizeFile(file) {
-  // Web servers will have a prefix like: http://localhost:8000/app.js (needs to be just app.js)
-  // Files from Windows something like: file:///C:/temp/app.js (needs to be just /temp/app.js)
-  // Files from Linux something like: file:///home/bill/app.js (needs to be just /home/bill/app.js)
+  // When tracing from the browser, additional filename formats need to be handled:
+  //  - Web servers will have a format like: http://localhost:8000/app.js (needs to be just app.js)
+  //  - Files from Windows something like: file:///C:/temp/app.js (needs to be just /temp/app.js)
+  //  - Files from Linux something like: file:///home/bill/app.js (needs to be just /home/bill/app.js)
   const webPrefix = /((https?:\/\/[^\/]*\/)|(file:\/\/\/[a-zA-Z]:)|(file:\/\/))/
   file = file.replace(webPrefix, "")
 
-  // Location includes :line:column to the end
+  // Location includes :line:column to the end. Note that browser traces include
+  // psuedo-filenames like "extensions::SafeBuiltins", so only consider the last
+  // two colons for a match.
   const re = /(.*):([0-9]+):([0-9]+)$/
   const array = re.exec(file)
   if (!array) return file

--- a/lib/log-processing/code-entry.js
+++ b/lib/log-processing/code-entry.js
@@ -3,8 +3,17 @@
 const { severityOfOptimizationState }  = require('./optimization-state')
 
 function normalizeFile(file) {
-  // Node.js adds :line:column to the end
-  return file.split(':')[0]
+  // Web servers will have a prefix like: http://localhost:8000/app.js (needs to be just app.js)
+  // Files from Windows something like: file:///C:/temp/app.js (needs to be just /temp/app.js)
+  // Files from Linux something like: file:///home/bill/app.js (needs to be just /home/bill/app.js)
+  const webPrefix = /((https?:\/\/[^\/]*\/)|(file:\/\/\/[a-zA-Z]:)|(file:\/\/))/
+  file = file.replace(webPrefix, "")
+
+  // Location includes :line:column to the end
+  const re = /(.*):([0-9]+):([0-9]+)$/
+  const array = re.exec(file)
+  if (!array) return file
+  return array[1]
 }
 
 class CodeEntry {

--- a/lib/log-processing/deopt-entry.js
+++ b/lib/log-processing/deopt-entry.js
@@ -4,17 +4,23 @@
 
 const { MIN_SEVERITY } = require('../severities')
 
-// <../examples/adders.js:93:27
-const sourcePositionRx = /[<]([^>]*):([0-9]+):([0-9]+)[>]$/
+// <../examples/adders.js:93:27 or <file:///C:/temp/trace/lib/app.js:20:12>
+// Note that the format may be something like the below, in which case the
+// first location shown is the better one to return.
+//    <lib/app.js:20:12> inlined at <lib/app.js:25:44>
+const sourcePositionRx = /[<]([^>]*):([0-9]+):([0-9]+)[>]/
 
 function normalizeFile(file) {
-  // Web servers will have a prefix like: http://localhost:8000/app.js (needs to be just app.js)
-  // Files from Windows something like: file:///C:/temp/app.js (needs to be just /temp/app.js)
-  // Files from Linux something like: file:///home/bill/app.js (needs to be just /home/bill/app.js)
+  // When tracing from the browser, additional filename formats need to be handled:
+  //  - Web servers will have a format like: http://localhost:8000/app.js (needs to be just app.js)
+  //  - Files from Windows something like: file:///C:/temp/app.js (needs to be just /temp/app.js)
+  //  - Files from Linux something like: file:///home/bill/app.js (needs to be just /home/bill/app.js)
   const webPrefix = /((https?:\/\/[^\/]*\/)|(file:\/\/\/[a-zA-Z]:)|(file:\/\/))/
   file = file.replace(webPrefix, "")
 
-  // Location includes :line:column to the end
+  // Location includes :line:column to the end. Note that browser traces include
+  // psuedo-filenames like "extensions::SafeBuiltins", so only consider the last
+  // two colons for a match.
   const re = /(.*):([0-9]+):([0-9]+)$/
   const array = re.exec(file)
   if (!array) return file

--- a/lib/log-processing/deopt-entry.js
+++ b/lib/log-processing/deopt-entry.js
@@ -5,7 +5,21 @@
 const { MIN_SEVERITY } = require('../severities')
 
 // <../examples/adders.js:93:27
-const sourcePositionRx = /[<]([^:]+):(\d+):(\d+)[>]/
+const sourcePositionRx = /[<]([^>]*):([0-9]+):([0-9]+)[>]$/
+
+function normalizeFile(file) {
+  // Web servers will have a prefix like: http://localhost:8000/app.js (needs to be just app.js)
+  // Files from Windows something like: file:///C:/temp/app.js (needs to be just /temp/app.js)
+  // Files from Linux something like: file:///home/bill/app.js (needs to be just /home/bill/app.js)
+  const webPrefix = /((https?:\/\/[^\/]*\/)|(file:\/\/\/[a-zA-Z]:)|(file:\/\/))/
+  file = file.replace(webPrefix, "")
+
+  // Location includes :line:column to the end
+  const re = /(.*):([0-9]+):([0-9]+)$/
+  const array = re.exec(file)
+  if (!array) return file
+  return array[1]
+}
 
 function safeToInt(x) {
   if (x == null) return 0
@@ -77,7 +91,7 @@ class DeoptEntry {
   static disassembleSourcePosition(sourcePosition) {
     const m = sourcePositionRx.exec(sourcePosition)
     if (m == null) return { file: null, line: 0, column: 0 }
-    return { file: m[1], line: safeToInt(m[2]), column: safeToInt(m[3]) }
+    return { file: normalizeFile(m[1]), line: safeToInt(m[2]), column: safeToInt(m[3]) }
   }
 }
 

--- a/lib/log-processing/ic-entry.js
+++ b/lib/log-processing/ic-entry.js
@@ -6,8 +6,17 @@ const {
 } = require('./ic-state')
 
 function normalizeFile(file) {
-  // Node.js adds :line:column to the end
-  return file.split(':')[0]
+  // Web servers will have a prefix like: http://localhost:8000/app.js (needs to be just app.js)
+  // Files from Windows something like: file:///C:/temp/app.js (needs to be just /temp/app.js)
+  // Files from Linux something like: file:///home/bill/app.js (needs to be just /home/bill/app.js)
+  const webPrefix = /((https?:\/\/[^\/]*\/)|(file:\/\/\/[a-zA-Z]:)|(file:\/\/))/
+  file = file.replace(webPrefix, "")
+
+  // Location includes :line:column to the end
+  const re = /(.*):([0-9]+):([0-9]+)$/
+  const array = re.exec(file)
+  if (!array) return file
+  return array[1]
 }
 
 function unquote(s) {

--- a/lib/log-processing/ic-entry.js
+++ b/lib/log-processing/ic-entry.js
@@ -6,13 +6,16 @@ const {
 } = require('./ic-state')
 
 function normalizeFile(file) {
-  // Web servers will have a prefix like: http://localhost:8000/app.js (needs to be just app.js)
-  // Files from Windows something like: file:///C:/temp/app.js (needs to be just /temp/app.js)
-  // Files from Linux something like: file:///home/bill/app.js (needs to be just /home/bill/app.js)
+  // When tracing from the browser, additional filename formats need to be handled:
+  //  - Web servers will have a format like: http://localhost:8000/app.js (needs to be just app.js)
+  //  - Files from Windows something like: file:///C:/temp/app.js (needs to be just /temp/app.js)
+  //  - Files from Linux something like: file:///home/bill/app.js (needs to be just /home/bill/app.js)
   const webPrefix = /((https?:\/\/[^\/]*\/)|(file:\/\/\/[a-zA-Z]:)|(file:\/\/))/
   file = file.replace(webPrefix, "")
 
-  // Location includes :line:column to the end
+  // Location includes :line:column to the end. Note that browser traces include
+  // psuedo-filenames like "extensions::SafeBuiltins", so only consider the last
+  // two colons for a match.
   const re = /(.*):([0-9]+):([0-9]+)$/
   const array = re.exec(file)
   if (!array) return file


### PR DESCRIPTION
This handles path issues if the v8.log file is generated on Windows, and/or from a browser session.

I also added some notes on how to create a browser trace to the readme, and worked around an issue in the v8-tool-core package until that is refreshed.