### PR TITLE
Fix parsing of DOS file system paths

### DIFF
--- a/deoptigate.js
+++ b/deoptigate.js
@@ -8,6 +8,7 @@ const { Profile } = require('v8-tools-core/profile')
 const IcEntry = require('./lib/log-processing/ic-entry')
 const DeoptEntry = require('./lib/log-processing/deopt-entry')
 const CodeEntry = require('./lib/log-processing/code-entry')
+const parseSourcePosition = require('./lib/log-processing/source-position')
 const { parseOptimizationState } = require('./lib/log-processing/optimization-state')
 
 const groupByFileAndLocation = require('./lib/grouping/group-by-file-and-location')
@@ -20,14 +21,8 @@ function maybeNumber(s) {
 function formatName(entry) {
   if (!entry) return '<unknown>'
   const name = entry.func.getName()
-  const re = /(.*):([0-9]+):([0-9]+)$/
-  const array = re.exec(name)
-  if (!array) return { fnFile: name, line: -1, column: -1 }
-  return {
-      fnFile: array[1]
-    , line: maybeNumber(array[2])
-    , column: maybeNumber(array[3])
-  }
+  const { file: fnFile, line, column } = parseSourcePosition(name);
+  return { fnFile, line, column };
 }
 
 function locationKey(file, line, column) {

--- a/lib/grouping/location.js
+++ b/lib/grouping/location.js
@@ -6,9 +6,14 @@ function keyLocation({ functionName, line, column }) {
   return `${functionName}:${line}:${column}`
 }
 
+// allow DOS disk paths for script items (i.e. 'C:\path\to\file')
+const locationRx = /^((?:[a-z]:)?[^:]+)(?::(\d+):(\d+))?$/i
+
 function unkeyLocation(key) {
   if (key == null) return null
-  const [ functionName, line, column ] = key.split(':')
+  const m = locationRx.exec(key);
+  if (m == null) return null
+  const [, functionName, line, column ] = m
   return { functionName, line: parseInt(line), column: parseInt(column) }
 }
 

--- a/lib/grouping/resolve-files.js
+++ b/lib/grouping/resolve-files.js
@@ -34,6 +34,7 @@ async function resolveFiles(data) {
 
   const filesSet = new Set(
     ics.map(x => x.file)
+      .filter(x => x != null)
       .concat(deopts.map(x => x.file))
       .concat(codes.map(x => x.file))
   )

--- a/lib/log-processing/code-entry.js
+++ b/lib/log-processing/code-entry.js
@@ -1,10 +1,11 @@
 'use strict'
 
 const { severityOfOptimizationState }  = require('./optimization-state')
+const parseSourcePosition = require('./source-position')
 
 function normalizeFile(file) {
   // Node.js adds :line:column to the end
-  return file.split(':')[0]
+  return parseSourcePosition(file).file
 }
 
 class CodeEntry {

--- a/lib/log-processing/deopt-entry.js
+++ b/lib/log-processing/deopt-entry.js
@@ -3,18 +3,13 @@
 /* eslint-disable camelcase */
 
 const { MIN_SEVERITY } = require('../severities')
-
-// <../examples/adders.js:93:27
-const sourcePositionRx = /[<]([^:]+):(\d+):(\d+)[>]/
-
-function safeToInt(x) {
-  if (x == null) return 0
-  return parseInt(x)
-}
+const parseSourcePosition = require('./source-position')
 
 const SOFT = MIN_SEVERITY
 const LAZY = MIN_SEVERITY + 1
 const EAGER = MIN_SEVERITY + 2
+
+const sourcePositionRx = /^<(.+?)>(?: inlined at <(.+?)>)?$/;
 
 function getSeverity(bailoutType) {
   switch (bailoutType) {
@@ -75,9 +70,15 @@ class DeoptEntry {
   }
 
   static disassembleSourcePosition(sourcePosition) {
-    const m = sourcePositionRx.exec(sourcePosition)
-    if (m == null) return { file: null, line: 0, column: 0 }
-    return { file: m[1], line: safeToInt(m[2]), column: safeToInt(m[3]) }
+    const m = sourcePositionRx.exec(sourcePosition);
+    if (m) {
+      const source = parseSourcePosition(m[1]);
+      if (m[2]) {
+        source.inlinedAt = parseSourcePosition(m[2]);
+      }
+      return source;
+    }
+    return parseSourcePosition(sourcePosition)
   }
 }
 

--- a/lib/log-processing/ic-entry.js
+++ b/lib/log-processing/ic-entry.js
@@ -4,10 +4,11 @@ const {
     parseIcState
   , severityIcState
 } = require('./ic-state')
+const parseSourcePosition = require('./source-position')
 
 function normalizeFile(file) {
   // Node.js adds :line:column to the end
-  return file.split(':')[0]
+  return parseSourcePosition(file).file
 }
 
 function unquote(s) {

--- a/lib/log-processing/source-position.js
+++ b/lib/log-processing/source-position.js
@@ -1,0 +1,19 @@
+'use strict'
+
+// allow DOS disk paths (i.e. 'C:\path\to\file')
+const lineColumnRx = /:(\d+):(\d+)$/
+
+function safeToInt(x) {
+  if (x == null) return 0
+  return parseInt(x)
+}
+
+function parseSourcePosition(sourcePosition) {
+  const m = lineColumnRx.exec(sourcePosition)
+  if (m) {
+    return { file: sourcePosition.slice(0, m.index), line: safeToInt(m[1]), column: safeToInt(m[2]) }
+  }
+  return { file: sourcePosition, line: 0, column: 0 }
+}
+
+module.exports = parseSourcePosition

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,199 @@
+{
+  "name": "deoptigate",
+  "version": "0.5.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansicolors": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+      "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "files-provider": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/files-provider/-/files-provider-0.2.0.tgz",
+      "integrity": "sha1-ANXwh55QiieG6vyxuqC+0/9gYJ4=",
+      "requires": {
+        "promptly": "~3.0.3"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "ispawn": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ispawn/-/ispawn-0.2.0.tgz",
+      "integrity": "sha1-q7Oo7ZibvbhoFtsbIZIabZSNV9M=",
+      "requires": {
+        "pump": "~3.0.0",
+        "slow-kill": "~0.1.0",
+        "split2": "~2.2.0",
+        "through2": "~2.0.3"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "opn": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
+      "integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
+      "requires": {
+        "is-wsl": "^1.1.0"
+      }
+    },
+    "pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "promptly": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/promptly/-/promptly-3.0.3.tgz",
+      "integrity": "sha512-EWnzOsxVKUjqKeE6SStH1/cO4+DE44QolaoJ4ojGd9z6pcNkpgfJKr1ncwxrOFHSTIzoudo7jG8y0re30/LO1g==",
+      "requires": {
+        "pify": "^3.0.0",
+        "read": "^1.0.4"
+      }
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+      "requires": {
+        "mute-stream": "~0.0.4"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "slow-kill": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/slow-kill/-/slow-kill-0.1.0.tgz",
+      "integrity": "sha1-ttTTahPP+hmaD4V67KKaELLjBqQ="
+    },
+    "split2": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "requires": {
+        "through2": "^2.0.2"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "requires": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "v8-tools-core": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/v8-tools-core/-/v8-tools-core-0.1.1.tgz",
+      "integrity": "sha1-O27ELvHL2P9lfy8YOkH+fZh+ddw="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+    }
+  }
+}


### PR DESCRIPTION
Fixes handling of DOS-file system paths like `C:\path\to\file`. Also fixes path handling for inlined functions whose paths are represented as `<path/to/file:1:1> inlined as <path/to/file:2:1>`.

Depends on https://github.com/thlorenz/v8-tools-core/pull/1.