### PR TITLE
Correct spelling of 'inline caches'

### DIFF
--- a/app/build/deoptigate.js
+++ b/app/build/deoptigate.js
@@ -443,7 +443,7 @@ class SummaryView extends Component {
         React.createElement( 'div', { className: 'flex flex-row' },
           this._renderTabHeader('Optimizations', OPT_TAB_IDX),
           this._renderTabHeader('Deoptimizations', DEOPT_TAB_IDX),
-          this._renderTabHeader('Incline Caches', ICS_TAB_IDX)
+          this._renderTabHeader('Inline Caches', ICS_TAB_IDX)
         ),
         React.createElement( 'div', null,
           renderedCodes,

--- a/app/components/summary.js
+++ b/app/components/summary.js
@@ -76,7 +76,7 @@ class SummaryView extends Component {
         <div className='flex flex-row'>
           {this._renderTabHeader('Optimizations', OPT_TAB_IDX)}
           {this._renderTabHeader('Deoptimizations', DEOPT_TAB_IDX)}
-          {this._renderTabHeader('Incline Caches', ICS_TAB_IDX)}
+          {this._renderTabHeader('Inline Caches', ICS_TAB_IDX)}
         </div>
         <div>
           {renderedCodes}


### PR DESCRIPTION
Correct spelling: 'incline caches' -> 'inline caches'