### PR TITLE
fix: trace-ic -> log-ic

### DIFF
--- a/bin/deoptigate.create-log.js
+++ b/bin/deoptigate.create-log.js
@@ -8,6 +8,7 @@ const { promisify } = require('util')
 const access = promisify(fs.access)
 const mkdir = promisify(fs.mkdir)
 const stat = promisify(fs.stat)
+const semver = require('semver')
 
 const { brightBlack } = require('ansicolors')
 
@@ -79,9 +80,10 @@ async function createLog(args, head, simpleHead) {
   await createDirIfMissing(logDir)
 
   const logFile = `${tmpdir()}/deoptigate/v8.log`
+  let inlineCacheArg = semver.gte(process.version, '16.0.0') ? '--log-ic' : '--trace-ic'
 
   const execArgv = [
-      '--log-ic'
+      inlineCacheArg,
     , `--logfile=${logFile}`
     , '--no-logfile-per-isolate'
   ].concat(extraExecArgv)

--- a/bin/deoptigate.create-log.js
+++ b/bin/deoptigate.create-log.js
@@ -81,7 +81,7 @@ async function createLog(args, head, simpleHead) {
   const logFile = `${tmpdir()}/deoptigate/v8.log`
 
   const execArgv = [
-      '--trace-ic'
+      '--log-ic'
     , `--logfile=${logFile}`
     , '--no-logfile-per-isolate'
   ].concat(extraExecArgv)

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "ispawn": "~0.2.0",
     "mkdirp": "~0.5.1",
     "opn": "~5.4.0",
+    "semver": "^7.3.6",
     "v8-tools-core": "~0.1.1"
   },
   "keywords": [],


### PR DESCRIPTION
I believe this tool is no longer maintained, but, that's such an amazing tool. 

If you don't mind, I would like to help to support the latest Node.js version. Maybe summarize what's missing? I have run it in a small project and looks like most of the feature is not working (likely because of the new deopt/opt structure).